### PR TITLE
Fix syntax highlighting in code blocks

### DIFF
--- a/Categories/AlternativeDesigns.md
+++ b/Categories/AlternativeDesigns.md
@@ -12,7 +12,7 @@ Separately, C-style functions avoid adding to the Objective-C [binding time](htt
 
 ## Examples
 NSString+XYZExcitementAdditions.h
-```Objective-C
+```obj-c
 @interface NSString (XYZExcitementAdditions)
 - (NSString *)xyz_stringWithExcitement; // bad: potential name collisions
 @end
@@ -20,7 +20,7 @@ NSString+XYZExcitementAdditions.h
 NSString *XYZStringWithExcitement(NSString *string); // good: symbol safety
 ```
 NSString+XYZExcitementAdditions.m
-```Objective-C
+```obj-c
 #import "NSString+XYZExcitementAdditions.h"
 
 @implementation NSString (XYZExcitementAdditions)

--- a/Categories/Naming.md
+++ b/Categories/Naming.md
@@ -20,7 +20,7 @@ See [Apple's guidelines](https://developer.apple.com/library/archive/documentati
 
 ## Examples
 
-```Objective-C
+```obj-c
 // StringUtilities.h 
 // bad: doesn't use the full name of the original class, doesn't have a "+", no three letter prefix, and an overly-generic category name.
 

--- a/Classes/Naming.md
+++ b/Classes/Naming.md
@@ -12,7 +12,7 @@ Class names in Objective-C share a process global namepsace. Three letter prefix
 
 ## Examples
 
-```Objective-C
+```obj-c
 @interface Object : NSObject // bad: no three letter prefix
 @end
 

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -18,7 +18,7 @@ Using the three forward slash style of documentation distinguishes documentation
 
 ### Bad
 
-```Objective-C
+```obj-c
 @class XYZPerson;
 
 NSString *XYZPersonGetInitials(XYZPerson *person); // bad: return value ambiguous regarding locale awareness
@@ -35,7 +35,7 @@ NSString *XYZPersonGetInitials(XYZPerson *person); // bad: return value ambiguou
 
 ### Good
 
-```Objective-C
+```obj-c
 @class XYZPerson;
 
 /// Gets the initials of a person for an abbreviated representation in the UI.

--- a/Headers/Factoring.md
+++ b/Headers/Factoring.md
@@ -51,7 +51,7 @@ Private headers allow unit testing of internal methods while establishing the co
 
 ## Examples
 
-```Objective-C
+```obj-c
 // XYZObject.h
 @interface XYZObject : NSObject
 // ...

--- a/Headers/ImportAndInclude.md
+++ b/Headers/ImportAndInclude.md
@@ -12,7 +12,7 @@ Using `#import` eliminates the need for `#include` guards, which are not used by
 
 ## Examples
 
-```Objective-C
+```obj-c
 #include "XYZObjcClass.h" // bad: possible duplicate inclusion of this header
 #import "XYZObjcClass.h" // good: clang determines if this header has been included already and avoids duplicate inclusion
 #import "XYZPreprocessorModifier.h" // bad: may not be inlined here to affect the preprocessor state

--- a/Headers/Naming.md
+++ b/Headers/Naming.md
@@ -12,7 +12,7 @@ Header file names should describe their contents. By using the same name, the he
 
 ### Single Class
 
-```Objective-C
+```obj-c
 // Object.h 
 // bad: header name doesn't match class name
 
@@ -24,7 +24,7 @@ Header file names should describe their contents. By using the same name, the he
 
 ### Multiple Classes
 
-```Objective-C
+```obj-c
 // bad: multiple classes defined in the same file
 @interface XYZObject : NSObject
 @end
@@ -35,7 +35,7 @@ Header file names should describe their contents. By using the same name, the he
 
 ### Protocol
 
-```Objective-C
+```obj-c
 // XYZViewProtocols.h
 // bad: doesn't match the protocol name
 
@@ -50,7 +50,7 @@ Header file names should describe their contents. By using the same name, the he
 
 ### Class and Related Protocol
 
-```Objective-C
+```obj-c
 // XYZObjectAndProtocols.h
 // bad: name doesn't match the class name
 

--- a/InstanceVariables/Naming.md
+++ b/InstanceVariables/Naming.md
@@ -14,7 +14,7 @@ A lowercase letter after the underscore followed by additional alphanumeric char
 
 ## Examples
 
-```Objective-C
+```obj-c
 @implementation MyObject {
 @private
 	NSString *_name; // good

--- a/InstanceVariables/Patterns.md
+++ b/InstanceVariables/Patterns.md
@@ -16,7 +16,7 @@ When instance variables back properties, the implementation of the accessor meth
 
 ### Bad
 
-```Objective-C
+```obj-c
 // XYZObject.h
 @interface XYZObject : NSObject { // bad: instance variables should be declared from the `@implementation`
 @public // bad: instance variables should be private
@@ -52,7 +52,7 @@ When instance variables back properties, the implementation of the accessor meth
 
 ### Good
 
-```Objective-C
+```obj-c
 // XYZObject.h
 @interface XYZObject : NSObject
 @property (nonatomic) NSUInteger age;

--- a/MethodsAndImplementations/AutomaticReferenceCounting.md
+++ b/MethodsAndImplementations/AutomaticReferenceCounting.md
@@ -15,7 +15,7 @@ Analyzing object lifetime can be complex. With ARC, the compiler ensures correct
 
 ### Code compiled without ARC (`-fno-objc-arc`)
 
-```Objective-C
+```obj-c
 NSScanner *scanner = [[NSScanner alloc] initWithString:string];
 [scanner scanInt:&value1];
 [scanner release]; // bad: premature release of object
@@ -25,7 +25,7 @@ NSScanner *scanner = [[NSScanner alloc] initWithString:string];
 
 ### Code compiled with ARC (`-f-objc-arc`)
 
-```Objective-C
+```obj-c
 NSScanner *scanner = [[NSScanner alloc] initWithString:string];
 [scanner scanInt:&value1];
 ...

--- a/MethodsAndImplementations/EarlyReturns.md
+++ b/MethodsAndImplementations/EarlyReturns.md
@@ -14,7 +14,7 @@ Methods with multiple return statements may become hard to maintain over time. W
 
 ### Early Returns
 
-```Objective-C
+```obj-c
 - (CFIndex)indexOfFirstTokenFromString:(CFStringRef)string withLength:(NSInteger)length {
     CFLocaleRef locale = CFLocaleCopyCurrent();
 	CFStringTokenizerRef tokenizer = CFStringTokenizerCreate(kCFAllocatorDefault,
@@ -42,7 +42,7 @@ Methods with multiple return statements may become hard to maintain over time. W
 
 ### No Early Returns
 
-```Objective-C
+```obj-c
 - (CFIndex)indexOfFirstTokenFromString:(CFStringRef)string withLength:(NSInteger)length {
     CFIndex index = NSNotFound;
     CFLocaleRef locale = CFLocaleCopyCurrent();

--- a/MethodsAndImplementations/ImplicitBooleanConversion.md
+++ b/MethodsAndImplementations/ImplicitBooleanConversion.md
@@ -10,7 +10,7 @@ Avoid implicit conversions to boolean.
 
 ## Examples
 
-```Objective-C
+```obj-c
 NSObject *object = [[NSObject alloc] init];
 CGFloat floatValue = 9.0;
 BOOL booleanFlag = YES;

--- a/MethodsAndImplementations/RedundantMethodInvocations.md
+++ b/MethodsAndImplementations/RedundantMethodInvocations.md
@@ -14,7 +14,7 @@ We experienced a real world performance regression where a property was repeated
 
 ## Examples
 
-```Objective-C
+```obj-c
 
 @implementation MyView
 

--- a/Protocols/DelegatesAndDataSources.md
+++ b/Protocols/DelegatesAndDataSources.md
@@ -22,7 +22,7 @@ Apple's delegate and data source protocols as a rule include the word `Delegate`
 
 ### Bad
 
-```Objective-C
+```obj-c
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol XYZCustomViewTapping; // bad: this protocol follows the delegate pattern and should end with Delegate
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_END
 
 ### Good
 
-```Objective-C
+```obj-c
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol XYZCustomViewDelegate;

--- a/Protocols/Naming.md
+++ b/Protocols/Naming.md
@@ -12,7 +12,7 @@ The [Code Naming Basics](https://developer.apple.com/library/archive/documentati
 
 ## Examples
 
-```Objective-C
+```obj-c
 // Group of behaviors unrelated to a class
 @protocol NSLock; // bad: sounds like a class name
 @protocol NSLocking; // good

--- a/Protocols/Patterns.md
+++ b/Protocols/Patterns.md
@@ -22,7 +22,7 @@ Unit test code can result in better design and more maintainable code. Using pro
 
 ### Separation of concerns within protocols
 #### Bad
-```Objective-C
+```obj-c
 // NSAppearanceCustomizationAndMouseHandling.h
 @protocol NSAppearanceCustomizationAndMouseHandling <NSObject> // bad: protocol conflates multiple concepts
 @required
@@ -59,7 +59,7 @@ Unit test code can result in better design and more maintainable code. Using pro
 ```
 
 #### Good
-```Objective-C
+```obj-c
 // NSAppearanceCustomization.h
 @protocol NSAppearanceCustomization <NSObject> // good: protocol behaviors are related
 @required
@@ -89,7 +89,7 @@ Unit test code can result in better design and more maintainable code. Using pro
 
 ### Using protocols reduces code duplication 
 #### Bad
-```Objective-C
+```obj-c
 // NSWindow.h
 @interface NSWindow : NSResponder
 
@@ -124,7 +124,7 @@ if ([someObject isKindOfClass:[NSWindow class]]) { // bad: duplication of code s
 ```
 
 #### Good
-```Objective-C
+```obj-c
 // NSAppearanceCustomization.h
 @protocol NSAppearanceCustomization <NSObject>
 @required
@@ -156,7 +156,7 @@ if ([someObject conformsToProtocol:@protocol(NSAppearanceCustomization)]) { // g
 
 ### Unit Testing
 #### Bad
-```Objective-C
+```obj-c
 // bad: this method directly modifies the file system making it hard to unit test
 - (void)deleteItemFromFileSystemWithPath:(NSString *)path { 
     NSFileManager *defaultManager = [NSFileManager defaultManager];
@@ -168,7 +168,7 @@ if ([someObject conformsToProtocol:@protocol(NSAppearanceCustomization)]) { // g
 }
 ```
 #### Good
-```Objective-C
+```obj-c
 @protocol XYZItemRemoving <NSObject> // good: the relevant file manager API has been extracted
 - (BOOL)removeItemAtPath:(NSString *)path error:(NSError *_Nullable *)error;
 @end

--- a/Syntax/DotNotation.md
+++ b/Syntax/DotNotation.md
@@ -16,7 +16,7 @@ For further reading, others such as [Big Nerd Ranch](https://www.bignerdranch.co
 
 ## Examples
 
-```Objective-C
+```obj-c
 @implementation MyView
 
 - (void)updateFrame {

--- a/Syntax/Generics.md
+++ b/Syntax/Generics.md
@@ -16,7 +16,7 @@ Generics provide compile-time type checking to verify that collections, such as 
 
 Maintaining type consistency is more difficult without generics. Here is a for-each loop, which mistakenly declares the type of each item in the array as `NSString *`. `NSString` also provides an implementation of `doubleValue`, so the compiler does not emit any errors because there are no type checking errors after the implicit `id` to `NSString *` conversion.
 
-```Objective-C
+```obj-c
 - (NSNumber *)average:(NSArray *)ages {
     double average = 0; 
     NSUInteger count = [ages count];
@@ -38,7 +38,7 @@ Maintaining type consistency is more difficult without generics. Here is a for-e
 
 However, with generics, this code will fail to compile due to the type mismatch between generic type provided for the array (`NSNumber *`) and `NSString *` type used in the for-each loop.
 
-```Objective-C
+```obj-c
 - (NSNumber *)average:(NSArray<NSNumber *> *)ages {
     double average = 0; 
     NSUInteger count = [ages count];


### PR DESCRIPTION
GitHub Pages use Jekyll & rouge for syntax highlighting, which doesn't seem to like the capitalization/spelling of \`\`\`Objective-C at the start of our code blocks. Switch to \`\`\`obj-c which it does like. Confirm locally that syntax highlighting does start to work after this change.