### PR TITLE
Add page on implicit single line scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Not all teams use every convention documented here and others may be tweaked to 
 * [Syntax](Syntax.md)
   * [Dot Notation](Syntax/DotNotation.md)
   * [Generics](Syntax/Generics.md)
+  * [Scope](Syntax/Scope.md)
 
 # Legal Notices
 

--- a/Syntax.md
+++ b/Syntax.md
@@ -4,3 +4,4 @@
 
  * [Dot Notation](Syntax/DotNotation.md)
  * [Generics](Syntax/Generics.md)
+ * [Scope](Syntax/Scope.md)

--- a/Syntax/Scope.md
+++ b/Syntax/Scope.md
@@ -1,0 +1,39 @@
+# Scope
+
+## Convention
+Avoid implicit single-line scope. Instead use curly braces (`{}`) to explicitly define scope.
+
+## Rationale
+Adding curly braces for single line logic statements prevents errors in maintenance and refactoring over time. These types of refactoring issues around single-line if statements being refactored for multiple lines have caused real-world regressions, including a [high-profile security issue](https://www.imperialviolet.org/2014/02/22/applebug.html) in Apple's TLS/SSL stack.
+
+## Examples
+
+```obj-c
+// bad: without brackets, the scope of the if statement is implicitly just the next statement which can be missed in refactoring
+if (booleanStatement)
+    [self executeConditionalLogic]
+[self executeUnconditionalLogic]
+
+// bad: whitespace can exacerbate this issue
+if (booleanStatement)
+    [self executeConditionalLogic]
+    [self executeUnconditionalLogic]
+
+// good: the curly braces explicitly define the scope of the logical statement and which logic will execute unconditionally
+if (booleanStatement) {
+    [self executeLogic]
+}
+[self executeUnconditionalLogic]
+
+// bad: this single line statement relies on implicit scope and whether the nonLoopLogic executes as part of the loop could be clearer
+while ([self shouldLoop]) [self executeLoop]
+[self executeNonLoopLogic]
+
+// bad: whitespace can exacerbate this issue
+while ([self shouldLoop]) [self executeLoop]
+    [self executeNonLoopLogic]
+
+// good: the explicit curly braces makes it obvious that the non-loop logic executes outside of the while loop
+while ([self shouldLoop]) { [self executeLoop]; }
+[self executeNonLoopLogic]
+```

--- a/Syntax/Scope.md
+++ b/Syntax/Scope.md
@@ -28,14 +28,14 @@ if (booleanStatement) {
 [self executeUnconditionalLogic]
 
 // bad: this single line statement relies on implicit scope and whether the nonLoopLogic executes as part of the loop could be clearer
-while ([self shouldLoop]) [self executeLoop]
+while ([self shouldLoop]) [self executeLoopLogic]
 [self executeNonLoopLogic]
 
 // bad: whitespace can exacerbate this issue
-while ([self shouldLoop]) [self executeLoop]
+while ([self shouldLoop]) [self executeLoopLogic]
     [self executeNonLoopLogic]
 
 // good: the explicit curly braces makes it obvious that the non-loop logic executes outside of the while loop
-while ([self shouldLoop]) { [self executeLoop]; }
+while ([self shouldLoop]) { [self executeLoopLogic]; }
 [self executeNonLoopLogic]
 ```

--- a/Syntax/Scope.md
+++ b/Syntax/Scope.md
@@ -3,6 +3,8 @@
 ## Convention
 Avoid implicit single-line scope. Instead use curly braces (`{}`) to explicitly define scope.
 
+> This convention, while not necessarily specific to Objective-C, has helped us improve the factoring and organization of our code. Although adopted to different degrees by different teams, we felt this was worth including to document rationale for teams that find the convention useful.
+
 ## Rationale
 Adding curly braces for single line logic statements prevents errors in maintenance and refactoring over time. These types of refactoring issues around single-line if statements being refactored for multiple lines have caused real-world regressions, including a [high-profile security issue](https://www.imperialviolet.org/2014/02/22/applebug.html) in Apple's TLS/SSL stack.
 


### PR DESCRIPTION
Add a page about avoiding implicit single line scope. Closes #8. I recommend viewing the rich diff of the convention page for syntax highlighting.