### PR TITLE
Add simple dark mode support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,11 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
     {% seo %}
-    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" type="text/css" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" type="text/css" href="{{ "/assets/css/dark-mode-override.css?v=" | append: site.github.build_revision | relative_url }}">
 </head>
 <body>
     {% include search-lunr.html %}
-
+    
     <div class="container-lg px-3 my-5 markdown-body">
         <div style='display:flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #eaecef;'>
             {% if site.title and site.title != page.title %}
@@ -22,11 +23,11 @@
                 </form>
             </div>
         </div>
-
+        
         <div id="lunrsearchresults">
             <ul></ul>
         </div>
-
+        
         {{ content }}
         
         {% if site.github.private != true and site.github.license %}

--- a/assets/css/dark-mode-override.css
+++ b/assets/css/dark-mode-override.css
@@ -1,0 +1,9 @@
+/* set the background color to black when client requests dark mode and invert the colors
+   from post by user lewisl9029: https://news.ycombinator.com/item?id=26472246
+ */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: black;
+        filter: hue-rotate(180deg) invert(90%);
+    }
+}


### PR DESCRIPTION
Use a clever css trick to enable dark mode on our guideline sites by inverting the colors based on the system theme preferences.

Found the css color inversion trick on https://news.ycombinator.com/item?id=26472246.

Check it out in action:
www.markavitale.com/objc-guide

Tested on:
- Edge on macOS
- Safari on macOS

Documentation on the prefers-color-scheme media selector indicates it is supported almost everywhere.
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

Video of the interface:

https://user-images.githubusercontent.com/658243/111500486-0bad4d00-8712-11eb-8998-14982709b734.mov

