### PR TITLE
adding few more guidance

### DIFF
--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -14,6 +14,8 @@ Place documentation only on an entity's declaration. If it has no declaration (e
 
 Using the three forward slash style of documentation distinguishes documentation comments from other non-documentation comments. This matches the [Swift recommended documentation style](https://swift.org/documentation/api-design-guidelines/), enabling better documentation block consistency across languages.
 
+Xcode can automatically add these for you. Put your cursor in the method/enum/etc. and then Editor menu -> Structure submenu -> add documentation or "Option + command + forward slash (“/“)"
+
 ## Examples
 
 ### Bad

--- a/MethodsAndImplementations/Naming.md
+++ b/MethodsAndImplementations/Naming.md
@@ -1,6 +1,11 @@
 ## Convention
-- Start the name with a lowercase letter and capitalize the first letter of embedded words. Don’t use prefixes. See Typographic Conventions.
-- There are two specific exceptions to these guidelines. You may begin a method name with a well-known acronym in uppercase (such as TIFF or PDF)), and you may use prefixes to group and identify private methods (see Private Methods).
+- Start the name with a lowercase letter and capitalize the first letter of embedded words. Don’t use prefixes. For names composed of multiple words, do not use punctuation marks as parts of names or as separators. See [Typographic Conventions](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html#//apple_ref/doc/uid/20001281-1002931). There are two specific exceptions to these guidelines. You may begin a method name with a well-known acronym in uppercase (such as TIFF or PDF)), and you may use prefixes to group and identify private methods (see Private Methods).
+- For methods that represent actions an object takes, start the name with a verb.
+- If the method returns an attribute of the receiver, name the method after the attribute. The use of “get” is unnecessary, unless one or more values are returned indirectly.
+- Use keywords before all arguments.
+- Make the word before the argument describe the argument.
+- Add new keywords to the end of an existing method when you create a method that is more specific than the inherited one.
+- Don’t use “and” to link keywords that are attributes of the receiver
+- If the method describes two separate actions, use “and” to link them.
 
-For methods that represent actions an object takes, start the name with a verb:
 For Apple guidelines, please refer [Naming Methods](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html#//apple_ref/doc/uid/20001282-BCIGIJJF)

--- a/MethodsAndImplementations/Naming.md
+++ b/MethodsAndImplementations/Naming.md
@@ -1,0 +1,6 @@
+## Convention
+- Start the name with a lowercase letter and capitalize the first letter of embedded words. Don’t use prefixes. See Typographic Conventions.
+- There are two specific exceptions to these guidelines. You may begin a method name with a well-known acronym in uppercase (such as TIFF or PDF)), and you may use prefixes to group and identify private methods (see Private Methods).
+
+For methods that represent actions an object takes, start the name with a verb:
+For Apple guidelines, please refer [Naming Methods](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html#//apple_ref/doc/uid/20001282-BCIGIJJF)

--- a/ObjectCreation/ClassInitialization.md
+++ b/ObjectCreation/ClassInitialization.md
@@ -1,0 +1,29 @@
+## Convention
+Use the instancetype keyword as the return type of methods that return an instance of the class they are called on (or a subclass of that class). These methods include alloc, init, and class factory methods. Using `instancetype` instead of `id` in appropriate places improves type safety in your Objective-C code.
+
+In Objective-C, object initialization is based on the notion of a designated initializer, an initializer method that is responsible for calling one of its superclass’s initializers and then initializing its own instance variables. The designated initializer pattern helps ensure that inherited initializers properly initialize all instance variables. When using `NS_DESIGNATED_INITIALIZER`, mark "init" `NS_UNAVAILABLE`.
+
+For Apple guidelines, please refer [Object Initialization](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html)
+
+
+## Examples
+
+```obj-c
+/// in header file
+@interface Object : NSObject
+- (instancetype)initWithObject:(Foo *)foo NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+/// in .m or .mm file
+@implementation Object : 
+- (instancetype)initWithObject:(Foo *)foo {
+    self = [super init];
+    if (self != nil)
+    {
+        // custom initialization with object foo
+    }
+    return self
+}
+@end
+```

--- a/ObjectCreation/ClassInitialization.md
+++ b/ObjectCreation/ClassInitialization.md
@@ -9,10 +9,15 @@ For Apple guidelines, please refer [Object Initialization](https://developer.app
 ## Examples
 
 ```obj-c
-/// in header file
+/// bad : in header file
 @interface Object : NSObject
-- (instancetype)initWithObject:(Foo *)foo NS_DESIGNATED_INITIALIZER;
-- (instancetype)init NS_UNAVAILABLE;
+- (id)initWithObject:(Foo *)foo; // bad : use of id and not declaring designated initializer if object foo is critical
+@end
+
+/// good : in header file
+@interface Object : NSObject
+- (instancetype)initWithObject:(Foo *)foo NS_DESIGNATED_INITIALIZER; // good: explicit designated initializer
+- (instancetype)init NS_UNAVAILABLE; // good make default NSObject init unavailable
 @end
 
 /// in .m or .mm file

--- a/Properties/Attributes.md
+++ b/Properties/Attributes.md
@@ -1,0 +1,58 @@
+# Basics
+If declaring NSString property in ARC environement, use `copy` instead of `strong`.
+
+Under the hood, `copy` for immutable objects just does a strong reference (it doesn't actually copy the objects). However, if the object is mutable (i.e. NSMutableString, for example), then it does do a copy (and that copy is fast, but more about that later).
+
+This prevents somebody from doing something like this contrived example:
+```obj-c
+@interface Person : NSObject 
+// note that these are strong, not copy 
+@property (readwrite, strong, nonatomic) NSString *firstName; 
+@property (readwrite, strong, nonatomic) NSString *fullName; 
+@end 
+
+@implementation Person
+@end
+  
+// caller code in a different file
+Person *person = [[Person alloc] init]; 
+NSMutableString *string = [[NSMutableString alloc] initWithString:@"Todd"]; 
+[person setFirstName:string]; 
+[string appendString:@" Harris"]; 
+[person setFullName:string];
+```
+At this point, if we were to print out firstName, we’d get “Todd Harris”, and fullName is “Todd Harris”. 
+If we change the code to do copy instead of strong:
+  
+```obj-c
+@interface Person : NSObject 
+@property (readwrite, copy, nonatomic) NSString *firstName;
+@property (readwrite, copy, nonatomic) NSString *fullName; 
+@end
+```
+
+And run the code again, we’ll get the expected behavior. 
+
+Copy can be used for anything implementing NSCopying (NSArray, NSDictionary, NSString, NSSet, etc.). As mentioned earlier that copy is fast for mutable objects - and that’s mostly true. It delays the actual copy until the next write. 
+
+If we consider the original code:
+```obj-c
+NSMutableString *string = [[NSMutableString alloc] initWithString:@"Todd"]; 
+[person setFirstName:string];
+```
+At this point, string has been done a copy. So internally, it’s created a new NSString object, and pointed it at the internal bytes that we’re pointing at (which stores @“Todd”) and some flag is set to keep track that we’ve done this.So then when we get to this line: 
+```obj-c
+[string appendString:@" Harris"];
+```
+Internally to appendString: (or any API which modifies the string) is where the copy is actually done. Since we set that flag earlier, we know that we can’t just modify the bytes that we were pointing to. Instead, we need to copy them to a new place and then write out @“ Harris” to those bytes. 
+
+Why does it delay the copy? Well, considering the use case where you might construct a mutable object and then hand it off as immutable, the system gets a huge perf win. Another example:
+```obj-c
+NSSet<NSNumber *> *GetLotteryPicks() { 
+    NSMutableSet<NSNumber *> *numbers = [[NSMutableSet alloc] init]; 
+    while ([numbers count]  < 6) {
+        [numbers addObject:@(rand() % 60)];  }  
+        return [numbers copy]; 
+    }
+```
+Since we create the mutable set just to build it and return it, we never end up doing any real copy of all of the objects in the set.

--- a/Properties/Attributes.md
+++ b/Properties/Attributes.md
@@ -1,5 +1,5 @@
 # Basics
-If declaring NSString property in ARC environement, use `copy` instead of `strong`.
+If declaring any class which supports [NSCopying](https://developer.apple.com/documentation/foundation/nscopying)--such as NSString, NSDate, NSArray etc--as a property in ARC environement, use `copy` instead of `strong`.
 
 Under the hood, `copy` for immutable objects just does a strong reference (it doesn't actually copy the objects). However, if the object is mutable (i.e. NSMutableString, for example), then it does do a copy (and that copy is fast, but more about that later).
 
@@ -16,12 +16,12 @@ This prevents somebody from doing something like this contrived example:
   
 // caller code in a different file
 Person *person = [[Person alloc] init]; 
-NSMutableString *string = [[NSMutableString alloc] initWithString:@"Todd"]; 
+NSMutableString *string = [[NSMutableString alloc] initWithString:@"Grace"]; 
 [person setFirstName:string]; 
-[string appendString:@" Harris"]; 
+[string appendString:@" Hopper"]; 
 [person setFullName:string];
 ```
-At this point, if we were to print out firstName, we’d get “Todd Harris”, and fullName is “Todd Harris”. 
+At this point, if we were to print out firstName, we’d get "Grace Hopper”, and fullName is “Grace Hopper”. 
 If we change the code to do copy instead of strong:
   
 ```obj-c
@@ -37,14 +37,14 @@ Copy can be used for anything implementing NSCopying (NSArray, NSDictionary, NSS
 
 If we consider the original code:
 ```obj-c
-NSMutableString *string = [[NSMutableString alloc] initWithString:@"Todd"]; 
+NSMutableString *string = [[NSMutableString alloc] initWithString:@"Grace"]; 
 [person setFirstName:string];
 ```
-At this point, string has been done a copy. So internally, it’s created a new NSString object, and pointed it at the internal bytes that we’re pointing at (which stores @“Todd”) and some flag is set to keep track that we’ve done this.So then when we get to this line: 
+At this point, string has been done a copy. So internally, it’s created a new NSString object, and pointed it at the internal bytes that we’re pointing at (which stores @“Grace”) and some flag is set to keep track that we’ve done this.So then when we get to this line: 
 ```obj-c
-[string appendString:@" Harris"];
+[string appendString:@" Hopper"];
 ```
-Internally to appendString: (or any API which modifies the string) is where the copy is actually done. Since we set that flag earlier, we know that we can’t just modify the bytes that we were pointing to. Instead, we need to copy them to a new place and then write out @“ Harris” to those bytes. 
+Internally to appendString: (or any API which modifies the string) is where the copy is actually done. Since we set that flag earlier, we know that we can’t just modify the bytes that we were pointing to. Instead, we need to copy them to a new place and then write out @“ Hopper" to those bytes. 
 
 Why does it delay the copy? Well, considering the use case where you might construct a mutable object and then hand it off as immutable, the system gets a huge perf win. Another example:
 ```obj-c

--- a/Properties/Naming.md
+++ b/Properties/Naming.md
@@ -1,0 +1,13 @@
+## Convention
+A declared property effectively declares accessor methods for a property, and so conventions for naming a declared property are broadly the same as those for naming accessor methods (see Accessor Methods). If the property is expressed as a noun or a verb, the format is:
+
+```obj-c
+@property (…) type nounOrVerb;
+```
+
+If the name of a declared property is expressed as an adjective, however, the property name omits the “is” prefix but specifies the conventional name for the get accessor, for example:
+```obj-c
+@property (assign, getter=isEditable) BOOL editable;
+```
+
+For Apple guidelines, please refer [Declared Properties and Instance Variables](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-BAJGIIJE)

--- a/Properties/Patterns.md
+++ b/Properties/Patterns.md
@@ -1,0 +1,24 @@
+# Basic
+
+Use `Nulllable` or `Nonnull` annotation which also helps interop with Swift.
+```obj-c
+- (nullable AAPLListItem *)itemWithName:(nonnull NSString *)name;
+- (NSInteger)indexOfItem:(nonnull AAPLListItem *)item;
+```
+
+To ease adoption of the new annotations, you can mark certain regions of your Objective-C header files as audited for nullability with `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END`. Within these regions, any simple pointer type will be assumed to be nonnull. This collapses our earlier example down into something much simpler.
+```obj-c
+NS_ASSUME_NONNULL_BEGIN
+@interface AAPLList : NSObject <NSCoding, NSCopying>
+// ...
+- (nullable AAPLListItem *)itemWithName:(NSString *)name;
+- (NSInteger)indexOfItem:(AAPLListItem *)item;
+
+@property (copy, nullable) NSString *name;
+@property (copy, readonly) NSArray *allItems;
+// ...
+@end
+NS_ASSUME_NONNULL_END
+```
+
+For Apple guidelines, please refer [Nullability and Objective-C](https://developer.apple.com/swift/blog/?id=25)

--- a/Properties/Patterns.md
+++ b/Properties/Patterns.md
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSInteger)indexOfItem:(AAPLListItem *)item;
 
 @property (copy, nullable) NSString *name;
-@property (copy, readonly) NSArray *allItems;
+@property (copy, readonly) NSArray<AAPLListItem *> *allItems;
 // ...
 @end
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- naming convention on properties
- naming convention on methods
- encouraging use of NS_DESIGNATED_INITIALIZER
- encouraging use of  strong over copy for nsstring
- encouraging use of nullable or nonnull