### PR TITLE
Update external link on ImplicitBooleanConversion page

### DIFF
--- a/MethodsAndImplementations/ImplicitBooleanConversion.md
+++ b/MethodsAndImplementations/ImplicitBooleanConversion.md
@@ -6,7 +6,7 @@ Avoid implicit conversions to boolean.
 
 ## Rationale
 
-[Implicit Boolean Conversion](https://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html) can reduce code readability and hide bugs, especially when refactoring existing code. By making an explicit boolean comparison between a non-boolean type and a value of the same type, the context becomes less ambiguous and readers will not need to refer back to the type of the variable involved. Also note that Swift requires explicit conversions to a boolean type, so explicit checks in Objective-C increase the similarity in style between the two languages. As most types can be implicitly converted to boolean, refactoring code that uses implicit conversion may result in unexpected behavior. Explicit conversion clarifies intent, which can aid in improving the correctness of a refactor.
+[Implicit Boolean Conversion](https://releases.llvm.org/13.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-implicit-bool-conversion.html) can reduce code readability and hide bugs, especially when refactoring existing code. By making an explicit boolean comparison between a non-boolean type and a value of the same type, the context becomes less ambiguous and readers will not need to refer back to the type of the variable involved. Also note that Swift requires explicit conversions to a boolean type, so explicit checks in Objective-C increase the similarity in style between the two languages. As most types can be implicitly converted to boolean, refactoring code that uses implicit conversion may result in unexpected behavior. Explicit conversion clarifies intent, which can aid in improving the correctness of a refactor.
 
 ## Examples
 


### PR DESCRIPTION
**Issue:** 
Link on [this page](https://github.com/microsoft/objc-guide/blob/gh-pages/MethodsAndImplementations/ImplicitBooleanConversion.md) to the external "Implicit Boolean Conversion" page is broken.

**Fix:** 
Update link to a working URL --> https://releases.llvm.org/13.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-implicit-bool-conversion.html

**Validation:** 
Verified the link works